### PR TITLE
Removed now-redundant sentence and code segment.

### DIFF
--- a/factors.Rmd
+++ b/factors.Rmd
@@ -8,12 +8,7 @@ Historically, factors were much easier to work with than characters. As a result
 
 ### Prerequisites
 
-To work with factors, we'll use the __forcats__ package, which provides tools for dealing with **cat**egorical variables (and it's an anagram of factors!). It provides a wide range of helpers for working with factors. forcats is not part of the core tidyverse, so we need to load it explicitly.
-
-```{r setup, message = FALSE}
-library(tidyverse)
-library(forcats)
-```
+To work with factors, we'll use the __forcats__ package, which provides tools for dealing with **cat**egorical variables (and it's an anagram of factors!). It provides a wide range of helpers for working with factors.
 
 ### Learning more
 


### PR DESCRIPTION
Removed a now-redundant sentence:

> forcats is not part of the core tidyverse, so we need to load it explicitly.

forcats is now part of the core tidyverse and no longer needs to be loaded explicitly.